### PR TITLE
lock node version to 8.10

### DIFF
--- a/deploy/production-up.json
+++ b/deploy/production-up.json
@@ -8,5 +8,8 @@
   },
   "error_pages": {
     "disable": true
+  },
+  "lambda": {
+    "runtime": "nodejs8.10"
   }
 }

--- a/deploy/test-up.json
+++ b/deploy/test-up.json
@@ -8,5 +8,8 @@
   },
   "error_pages": {
     "disable": true
+  },
+  "lambda": {
+    "runtime": "nodejs8.10"
   }
 }


### PR DESCRIPTION
![](https://media1.giphy.com/media/3oz8xODcLLAxb8Qyju/giphy-downsized.gif?cid=6104955e8faf7fad25cf6221a890546090d5a8223bfe3444&rid=giphy-downsized.gif)

node 8 is going to be running out of support soon
we should upgrade all our lambda function to v10 as that is now supported by lambda

plan to do this
1) lock down all current functions to version 8
2) upgrade the up cli version on jenkins, which supports (and defaults) to node 10
3) one by one each service should be upgraded to node 10
4) reap the rewards